### PR TITLE
Add dependent sources

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DatasetManager"
 uuid = "2ca6b172-e30b-458d-964f-9c975788bc07"
 authors = ["Allen Hill <allenofthehills@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/julia-reference.md
+++ b/docs/src/julia-reference.md
@@ -24,6 +24,7 @@ hassource
 getsource
 sources
 findtrials
+findtrials!
 analyzedataset
 export_trials
 ```

--- a/src/DatasetManager.jl
+++ b/src/DatasetManager.jl
@@ -7,10 +7,10 @@ using Crayons.Box
 export DataSubset, TrialConditions, Trial, DuplicateSourceError, Segment, SegmentResult,
     AbstractSource, Source, MissingSourceError, UnknownDeps
 
-export findtrials, summarize, analyzedataset, export_trials, subject, conditions,
-    hascondition, sources, hassource, getsource, sourcepath, readsource, requiresource!,
-    generatesource, dependencies, segment, source, readsegment, trial, results,
-    resultsvariables
+export findtrials, findtrials!, summarize, analyzedataset, export_trials, subject,
+    conditions, hascondition, sources, hassource, getsource, sourcepath, readsource,
+    requiresource!, generatesource, dependencies, segment, source, readsegment, trial,
+    results, resultsvariables
 
 include("source.jl")
 include("trial.jl")

--- a/src/DatasetManager.jl
+++ b/src/DatasetManager.jl
@@ -8,9 +8,9 @@ export DataSubset, TrialConditions, Trial, DuplicateSourceError, Segment, Segmen
     AbstractSource, Source, MissingSourceError, UnknownDeps
 
 export findtrials, findtrials!, summarize, analyzedataset, export_trials, subject,
-    conditions, hascondition, sources, hassource, getsource, sourcepath, readsource,
-    requiresource!, generatesource, dependencies, segment, source, readsegment, trial,
-    results, resultsvariables
+    conditions, hascondition, renamecondition!, recodecondition!, sources, hassource,
+    getsource, sourcepath, readsource, requiresource!, generatesource, dependencies,
+    segment, source, readsegment, trial, results, resultsvariables
 
 include("source.jl")
 include("trial.jl")

--- a/src/summary.jl
+++ b/src/summary.jl
@@ -11,7 +11,7 @@ observed_levels(trials) = Dict( factor => unique(skipmissing(get.(conditions.(tr
 function conditions_isequal(condsA, condsB; ignore=nothing)
     if !isnothing(ignore)
         ign_k_condsA = setdiff(keys(condsA), ignore)
-        if intersect(ign_k_condsA, setdiff(keys(condsB), ignore)) == ign_k_condsA
+        if issetequal(ign_k_condsA, setdiff(keys(condsB), ignore))
             return all(isequal.(getindex.(Ref(condsA), ign_k_condsA),
                 getindex.(Ref(condsB), ign_k_condsA)))
         else

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -107,6 +107,15 @@ end
 str_rgx(r::Regex) = r.pattern
 str_rgx(str::String) = str
 
+# TODO: Add tests labels (ie values in `labels`) for:
+    # - Regex
+    # - Regex => Function
+    # - Regex => Function => Vector{String}
+    # - Regex => Function => Regex
+    # - Regex => SubstitutionString => Regex
+    # - Vector{String}
+    # - Vector{Union{String,Pair{Vector{String},String}}}
+    # - Vector{Pair{Vector{String},String}}
 function TrialConditions(
     conditions,
     labels;
@@ -129,7 +138,7 @@ function TrialConditions(
                 flag = "i"
             end
         elseif typeof(labels[cond]) <: Pair{Regex,Pair{T1,T2}} where {T1,T2}
-            if labels[cond].second.second isa Regex
+            if labels[cond].second.second isa Regex || labels[cond].second.second isa String
                 print(rg, str_rgx(labels[cond].second.second), ')')
             else
                 join(rg, (str_rgx(x) for x in labels[cond].second.second ), '|')

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -626,6 +626,10 @@ function findtrials!(
                         end
 
                         if hassource(t, src_name)
+                            if !@isdefined(_id)
+                                _id=gensym(file)
+                            end
+
                             let io = IOBuffer()
                                 showerror(io, DuplicateSourceError(t, set,
                                     sourcepath(t.sources[src_name]), file))

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -427,11 +427,6 @@ optionalparse(T, ::Nothing) = nothing
 optionalparse(::Type{T}, x::T) where T = x
 optionalparse(T, x::U) where {U} = T <: String ? String(x) : parse(T, x)
 
-_get(collection::RegexMatch, key, default) = haskey(collection, key) ? collection[key] : default
-_get(default::Base.Callable, collection::RegexMatch, key) = haskey(collection, key) ? collection[key] : default()
-_get(collection, key, default) = get(collection, key, default)
-_get(default::Base.Callable, collection, key) = get(default, collection, key)
-
 """
     findtrials(subsets::AbstractVector{DataSubset}, conditions::TrialConditions;
         <keyword arguments>) -> Vector{Trial}

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -300,6 +300,13 @@ Get the conditions for `trial`
 conditions(trial::Trial) = trial.conditions
 
 """
+    sources(trial::Trial{ID}) -> Dict{String,AbstractSource}
+
+Get the sources for `trial`
+"""
+sources(trial::Trial) = trial.sources
+
+"""
     hascondition(trial, condition...)
     hascondition(trial, (condition => value)...)
 
@@ -367,13 +374,6 @@ function recodecondition!(f, trial, cond)
     @assert hascondition(trial, cond)
     conditions(trial)[cond] = f(conditions(trial)[cond])
 end
-
-"""
-    sources(trial::Trial{ID}) -> Dict{String,AbstractSource}
-
-Get the sources for `trial`
-"""
-sources(trial::Trial) = trial.sources
 
 """
     hassource(trial, src::Union{String,S<:AbstractSource}) -> Bool

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -449,34 +449,39 @@ optionalparse(::Type{T}, x::T) where T = x
 optionalparse(T, x::U) where {U} = T <: String ? String(x) : parse(T, x)
 
 """
-    findtrials(subsets::AbstractVector{DataSubset}, conditions::TrialConditions;
-        <keyword arguments>) -> Vector{Trial}
+    findtrials(subsets, conditions; <keyword arguments>) -> Vector{Trial}
 
 Find all the trials matching `conditions` which can be found in `subsets`.
 
 # Keyword arguments:
 
-- `subject_fmt=r"(?<=Subject )(?<subject>\\d+)"`: The format that the subject identifier
-   will appear in file paths.
 - `ignorefiles::Union{Nothing, Vector{String}}=nothing`: A list of files, given in the form
    of an absolute path, that are in any of the `subsets` folders which are to be ignored.
-- `defaultconds::Union{Nothing, Dict{Symbol}}=nothing`: Any conditions which have a default
-   level if the condition is not found in the file path.
-- `debug=false`: Show Regex and files that did not match for each subset. Use to debug
-   `TrialConditions` definitions or issues with `subject_fmt` failing to match subject ID's.
+- `debug=false`: Show files that did not match (all) the required conditions
+- `verbose=false`: Show files that *did* match all required conditions when `debug=true`
+- `maxlogs=50`: Maximum number of files per subset to show when debugging
+
+See also: [`Trial`](@ref), [`findtrials!`](@ref), [`DataSubset`](@ref), [`TrialConditions`](@ref)
 """
 function findtrials(subsets::AbstractVector{DataSubset}, trialconds::TrialConditions; kwargs...)
     I = trialconds.types[:subject]
     findtrials!(Vector{Trial{I}}(), subsets, trialconds; kwargs...)
 end
 
+"""
+    findtrials!(trials, subsets, conditions; <keyword arguments>)
+
+Find and add new trials or new sources to existing trials.
+
+See also: [`findtrials`](@ref), [`Trial`](@ref), [`DataSubset`](@ref), [`TrialConditions`](@ref)
+"""
 function findtrials!(
     trials::Vector{Trial{I}},
     subsets::AbstractVector{DataSubset},
     trialconds::TrialConditions;
+    ignorefiles::Union{Nothing, Vector{String}}=nothing,
     debug=false,
     verbose=false,
-    ignorefiles::Union{Nothing, Vector{String}}=nothing,
     maxlogs=50,
 ) where I
     requiredconds = filter(!=(:subject), trialconds.required)

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -200,42 +200,42 @@ end
 
 function Base.show(io::IO, t::Trial)
     print(io, "Trial(", repr(t.subject), ", ", repr(t.name), ", ")
-    if get(io, :limit, false)
+    if get(io, :compact, true) || get(io, :limit, true)
+        print(io, length(conditions(t)), " conditions, ")
+    else
         print(io, '(')
-        _io = IOContext(io, :typeinfo=>eltype(t.conditions))
+        _io = IOContext(io, :typeinfo=>eltype(conditions(t)))
         first = true
-        for p in pairs(t.conditions)
+        for p in pairs(conditions(t))
             first || print(_io, ", ")
             first = false
             print(_io, p)
         end
         print(io, "), ")
-    else
-        print(io, length(t.conditions), " conditions, ")
     end
-    numsources = length(t.sources)
-    if numsources == 1
-        print(io, numsources, " source", ')')
-    else
-        print(io, numsources, " sources", ')')
-    end
+    numsources = length(sources(t))
+    plural = numsources == 1 ? "" : "s"
+    print(io, numsources, " source", plural, ')')
 end
 
 function Base.show(io::IO, ::MIME"text/plain", t::Trial{I}) where I
     println(io, "Trial{", I, "}")
     println(io, "  Subject: ", t.subject)
     println(io, "  Name: ", t.name)
-    print(io, "  Conditions:")
-    for c in t.conditions
-        print(io, "\n    ")
-        print(io, repr(c.first), " => ", repr(c.second))
+    println(io, "  Conditions:")
+    for c in conditions(t)
+        print(io, "    ")
+        println(io, repr(c.first), " => ", repr(c.second))
     end
-    print(io, "\n  Sources:")
-    for p in t.sources
-        print(io, "\n    ")
-        print(io, repr(p.first), " => ", repr(p.second))
+    if isempty(sources(t))
+        println(io, "  No sources")
+    else
+        println(io, "  Sources:")
+        for p in sources(t)
+            print(io, "    ")
+            println(io, repr(p.first), " => ", repr(p.second))
+        end
     end
-    println(io)
 end
 
 Base.isequal(x::Trial{I}, y::Trial{T}) where {I,T} = false

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -333,6 +333,20 @@ julia> filter(hascondition(:group => "A"), [trial1, trial2])
 hascondition(cond::Pair{Symbol}) = Base.Fix2(hascondition, cond)
 hascondition(conds::Vararg{Pair{Symbol,T} where T <: Any}) = Base.Fix2(hascondition, conds)
 
+function renamecondition!(trial, (old, new)::Pair)
+    @assert hascondition(trial, old)
+    @assert !hascondition(trial, new)
+    conditions(trial)[new] = conditions(trial)[old]
+    delete!(conditions(trial), old)
+
+    return nothing
+end
+
+function recodecondition!(f, trial, cond)
+    @assert hascondition(trial, cond)
+    conditions(trial)[cond] = f(conditions(trial)[cond])
+end
+
 """
     sources(trial::Trial{ID}) -> Dict{String,AbstractSource}
 

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -61,7 +61,7 @@ Describes the experimental conditions (aka factors) and the labels for levels wi
 - `labels` must have a key-value pair for each condition name. The value(s) for each key
   describes how that condition will be matched. Acceptable options include a Regex, a pair
   (`old` => `transf` [=> `new`], where `old` may be a Regex or one/multiple String(s), and
-  where `transf` may be a `Function` or a [`SubstitutionString`](@ref) (if `old` is a
+  where `transf` may be a `Function` or a `SubstitutionString` (if `old` is a
   Regex), and `new` is a Regex), or an array of any of the preceding. Keys in `labels` which
   are not included in `conditions` will be ignored.
 

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -1,9 +1,12 @@
 """
-    DataSubset(name, source::Type{<:AbstractSource}, dir, pattern)
+    DataSubset(name, source::Type{<:AbstractSource}, dir, pattern; [dependent=false])
 
-Describes a subset of data, where files found within `dir`, with (absolute) paths which
-match `pattern` (using [glob syntax](https://en.wikipedia.org/wiki/Glob_(programming))), are
-all of the same `AbstractSource` subtype.
+Describes a subset of data, where files found within `dir`, which match `pattern` (using
+[glob syntax](https://en.wikipedia.org/wiki/Glob_(programming))), are `source` sources.
+Independent sources (`dependent=false`) can be the only source in a new `Trial`, while
+dependent sources will only be added to existing trials.
+
+See also: [`Trial`](@ref), [`findtrials`](@ref), [`findtrials!`](@ref)
 
 # Examples
 

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -589,7 +589,9 @@ function findtrials!(
                     push!(trials, Trial(sid, name, conds,
                         Dict{String,AbstractSource}(set.name => set.source(file))))
                 else
-                    if !set.dependent
+                    if set.dependent
+                        _id=gensym(file)
+                    else
                         @assert length(seenall) == 1
                     end
 
@@ -605,7 +607,7 @@ function findtrials!(
                             let io = IOBuffer()
                                 showerror(io, DuplicateSourceError(t, set,
                                     sourcepath(t.sources[src_name]), file))
-                                @error String(take!(io))
+                                @error String(take!(io)) _id=_id maxlog=1
                             end
                         else
                             t.sources[src_name] = set.source(file)


### PR DESCRIPTION
The current/typical `findtrials` functionality creates a new `Trial` for every new candidate source from a given `DataSubset`, but some sources are not relevant as a standalone/independent `Trial` (e.g. maximal voluntary contraction "trials", when collecting EMG data, are only relevant to other actual trials within a given subject/session of a data collection).

This PR adds a new field, `dependent`, to `DataSubset` (defaults to false, maintaining previous behavior). Sources from a dependent `DataSubset` will not create new trials in `findtrials`, and will only be added to existing trials when the required conditions and a "condition" exists which matches the `DataSubset` name.

# Example
```julia
# Create labels for required conditions and dependent source types
labels = Dict(
    :subject => r"(?<=Patient )\d+",
    :session => r"(?<=Session )\d+",
    :mvic => r"mvic_[rl](bic|tric)",
)

# Define new `TrialConditions` with only :subject and :session as required conditions (which will match to existing trials)
conds = TrialConditions((:subject,:session,:mvic), labels; required=(:subject,:session,))

# Create dependent `DataSubset`. Note that the data subset name matches the condition name in `labels`
subsets = [
    DataSubset("mvic", Source{C3DFile}, c3dpath, "Subject [0-9]*/Session [0-2]/*.c3d"; dependent=true)
]

# Assumes prior creation/existence of an array `trials`
findtrials!(trials, subsets, conds)
```

For example, a source from the `"mvic"` DataSubset with a filename of `"Subject 3/Session 2/mvic_rbic.c3d"` would be recognized as having conditions `(:subject => 3, :session => 2, :mvic => "mvic_rbic")` and would be added as a source named `"mvic_rbic"` to all trials where `hascondition(:subject => 3, :session => 2)`.